### PR TITLE
Enable warning messages and fix everything necessary

### DIFF
--- a/src/generate/templates/ping-message-.h.in
+++ b/src/generate/templates/ping-message-.h.in
@@ -51,12 +51,12 @@ public:
     {
         msgData[0] = 'B';
         msgData[1] = 'R';
-        (uint16_t&)msgData[2] = {{total_payload}}
+        (uint16_t&)msgData[2] = static_cast<uint16_t>({{total_payload}}
 {%- for payload in m.payload %}
 {% if generator.is_vector(payload.type) %}
  + {{payload.name}}_length
 {%- endif %}
-{% endfor %}; // payload size
+{% endfor %}); // payload size
         (uint16_t&)msgData[4] = {{m.id}}; // ID
         msgData[6] = 0;
         msgData[7] = 0;

--- a/src/generate/templates/ping-message-.h.in
+++ b/src/generate/templates/ping-message-.h.in
@@ -19,7 +19,7 @@ namespace {{definition|capitalize}}Id
     static const uint16_t {{message|upper}} = {{m.id}};
 {% endfor %}
 {% endfor %}
-};
+}
 
 {% for message_type in messages %}
 {% for message in messages[message_type] %}

--- a/src/message/ping-message.h
+++ b/src/message/ping-message.h
@@ -62,9 +62,9 @@ public:
     uint16_t message_id()                    const { return (uint16_t&)msgData[4]; }
     void set_message_id(const uint16_t message_id) { (uint16_t&)msgData[4] = message_id; }
     uint8_t  source_device_id()              const { return msgData[6]; }
-    void set_source_device_id(const uint16_t device_id) { msgData[6] = device_id; }
+    void set_source_device_id(const uint8_t device_id) { msgData[6] = device_id; }
     uint8_t  destination_device_id()         const { return msgData[7]; }
-    void set_destination_device_id(const uint16_t device_id) { msgData[7] = device_id; }
+    void set_destination_device_id(const uint8_t device_id) { msgData[7] = device_id; }
     // to migrate legacy ping1d devices, a new message id should be used with the same fields + padding
     uint16_t checksum()                      const { return msgData[msgDataLength() - checksumLength] + (msgData[msgDataLength() - checksumLength + 1] << 8); }
     void set_checksum(uint16_t checksum)           { msgData[msgDataLength() - checksumLength] = (uint8_t)checksum; msgData[msgDataLength() - checksumLength + 1] = checksum >> 8; }

--- a/src/message/ping-message.h
+++ b/src/message/ping-message.h
@@ -66,8 +66,8 @@ public:
     uint8_t  destination_device_id()         const { return msgData[7]; }
     void set_destination_device_id(const uint8_t device_id) { msgData[7] = device_id; }
     // to migrate legacy ping1d devices, a new message id should be used with the same fields + padding
-    uint16_t checksum()                      const { return msgData[msgDataLength() - checksumLength] + (msgData[msgDataLength() - checksumLength + 1] << 8); }
-    void set_checksum(uint16_t checksum)           { msgData[msgDataLength() - checksumLength] = (uint8_t)checksum; msgData[msgDataLength() - checksumLength + 1] = checksum >> 8; }
+    uint16_t checksum()                      const { return static_cast<uint16_t>(msgData[msgDataLength() - checksumLength] + (msgData[msgDataLength() - checksumLength + 1] << 8)); }
+    void set_checksum(uint16_t checksum)           { msgData[msgDataLength() - checksumLength] = (uint8_t)checksum; msgData[msgDataLength() - checksumLength + 1] = static_cast<uint8_t>(checksum >> 8); }
 
     bool verifyChecksum() const {
         if(msgDataLength() > bufferLength()) {

--- a/src/message/ping-message.h
+++ b/src/message/ping-message.h
@@ -53,7 +53,7 @@ public:
 
     uint8_t* msgData;
     uint16_t bufferLength() const { return _bufferLength; } // size of internal buffer allocation
-    uint16_t msgDataLength() const { return headerLength + payload_length() + checksumLength; } // size of entire message buffer (header, payload, and checksum)
+    uint16_t msgDataLength() const { return static_cast<uint16_t>(headerLength + payload_length() + checksumLength); } // size of entire message buffer (header, payload, and checksum)
     uint8_t* message_data(uint32_t offset=0) const { return msgData + offset; }
     uint8_t* payload_data(uint16_t offset=0) const { return msgData + headerLength + offset; }
 
@@ -83,10 +83,10 @@ public:
     }
 
     uint16_t calculateChecksum() const {
-        uint16_t checksum = 0;
+        uint16_t calculatedChecksum = 0;
         for(uint32_t i = 0, data_size = msgDataLength() - checksumLength; i < data_size; i++) {
-            checksum += msgData[i];
+            calculatedChecksum = static_cast<uint16_t>(msgData[i] + calculatedChecksum);
         }
-        return checksum;
+        return calculatedChecksum;
     }
 };

--- a/src/message/ping-parser.h
+++ b/src/message/ping-parser.h
@@ -12,7 +12,7 @@ public:
     ping_message rxMessage; // This message is used as the rx buffer
     uint32_t parsed = 0; // number of messages/packets successfully parsed
     uint32_t errors = 0; // number of parse errors
-    
+
     // This enum MUST be contiguous
     enum ParseState {
         NEW_MESSAGE,   // Just got a complete checksum-verified message

--- a/src/message/ping-parser.h
+++ b/src/message/ping-parser.h
@@ -69,7 +69,7 @@ public:
             break;
         case WAIT_LENGTH_H:
             rxBuffer_[rxCount_++] = b;
-            payloadLength_ = (b << 8) | payloadLength_;
+            payloadLength_ = static_cast<uint16_t>((b << 8) | payloadLength_);
             if (payloadLength_ <= rxBufferLength_ - 8 - 2) {
                 state_++;
             } else {

--- a/src/message/ping-parser.h
+++ b/src/message/ping-parser.h
@@ -6,7 +6,7 @@
 class PingParser
 {
 public:
-    PingParser(uint32_t bufferLength = 512) : rxMessage(bufferLength), rxBuffer_(rxMessage.msgData) {}
+    PingParser(uint16_t bufferLength = 512) : rxMessage(bufferLength), rxBuffer_(rxMessage.msgData) {}
     ~PingParser() = default;
 
     ping_message rxMessage; // This message is used as the rx buffer

--- a/tools/travis-ci-script.sh
+++ b/tools/travis-ci-script.sh
@@ -5,7 +5,7 @@ git submodule update --init
 src/generate/generate-message.py --output-dir src/message
 
 echo "Run test.."
-if ! g++ test/test-message.cpp -std=c++11; then
+if ! g++ test/test-message.cpp -std=c++11 -pedantic -Wall -Werror -Wshadow -Wnarrowing -Wconversion; then
     echo " Failed to compile test-message!"
     exit 1
 fi


### PR DESCRIPTION
Since we are enabling some warnings and using werror in ping-viewer, this patch allows ping-viewer to compile without problems ping-cpp.

We should enable and use werror to allow a more safer code, principally in embedded boards. 