### PR TITLE
ping-message-all: Add nameFromMessageId function

### DIFF
--- a/src/generate/templates/ping-message-all.h.in
+++ b/src/generate/templates/ping-message-all.h.in
@@ -70,6 +70,29 @@ public:
         }
     }
 
+    /**
+     * @brief Helper function that provides the name of a message from the message ID number
+     *
+     * @param messageId
+     * @return constexpr const char*
+     */
+    static constexpr const char* nameFromMessageId(const PingEnumNamespace::PingMessageId messageId) {
+        switch(messageId) {
+{% for definition in global %}
+{% for messages in global[definition] %}
+{% for message_type in global[definition][messages] %}
+{% for message in global[definition][messages][message_type] %}
+            case(PingEnumNamespace::PingMessageId::{{definition|upper}}_{{message|upper}}):
+                return "{{message|upper}}";
+{% endfor %}
+{% endfor %}
+{% endfor %}
+{% endfor %}
+            default:
+                return "UNKNOWN";
+        }
+    }
+
 private:
     PingHelper() = default;
     ~PingHelper() = default;


### PR DESCRIPTION
The function works as a helper to provide the name of the message
from the message ID number

It's possible to check the output here: http://ix.io/22ro

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>