### PR TITLE
ping-message: Add getMessageAsString

### DIFF
--- a/src/generate/templates/ping-message-.h.in
+++ b/src/generate/templates/ping-message-.h.in
@@ -81,6 +81,37 @@ public:
 {% endif %}
 {% endfor %}
 {% endif %}
+{% if m.payload %}
+
+    int getMessageAsString(char* string, size_t size) const {
+        int written = ping_message::getMessageAsString(string, size);
+        if (written > 0 && written < static_cast<int>(size)) {
+            return snprintf(string + written, size - static_cast<size_t>(written),
+{% for payload in m.payload %}
+{% if generator.is_vector(payload.type) %}
+{% if payload.vector.sizetype %}
+{% else %}
+                "  {{payload.name}}: %s\n"
+{% endif %}
+{% else %}
+                "  {{payload.name}}: %d\n"
+{% endif %}
+{% endfor %}
+{% for payload in m.payload %}
+{% if generator.is_vector(payload.type) %}
+{% if payload.vector.sizetype %}
+{% else %}
+                , {{payload.name}}()
+{% endif %}
+{% else %}
+                , {{payload.name}}()
+{% endif %}
+{% endfor %}
+            );
+        }
+        return written;
+    }
+{% endif %}
 };
 
 {% endfor %}

--- a/src/message/ping-message.h
+++ b/src/message/ping-message.h
@@ -4,6 +4,7 @@
 #include <inttypes.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 class ping_message
 {
@@ -88,5 +89,19 @@ public:
             calculatedChecksum = static_cast<uint16_t>(msgData[i] + calculatedChecksum);
         }
         return calculatedChecksum;
+    }
+
+    int getMessageAsString(char* string, size_t size) const {
+        return snprintf(string, size,
+            "ping_message:\n"
+            " payload_length: %d\n"
+            " message_id: %d\n"
+            " src_device_id: %d\n"
+            " dst_device_id: %d\n"
+            , payload_length()
+            , message_id()
+            , source_device_id()
+            , destination_device_id()
+        );
     }
 };


### PR DESCRIPTION
- This allow us to print any message with an C-like call
- It works with arduino
- It does not print vectors type, like profile messages data points [for logic reasons]
- it works with strings like messages, NACK

Examples: https://paste.rs/3Ak.C

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>