### PR TITLE
Improve device test

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/ping-protocol"]
 	path = lib/ping-protocol
 	url = https://github.com/bluerobotics/ping-protocol
+[submodule "lib/fmt"]
+	path = lib/fmt
+	url = https://github.com/fmtlib/fmt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ include_directories(${Boost_INCLUDE_DIR})
 # Include modules
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)
 
+# Add fmt
+include_directories(lib/fmt/include/)
+add_subdirectory(lib/fmt/)
+
 # test-device
 add_executable(test-device)
 target_sources(
@@ -33,6 +37,7 @@ PRIVATE
     HAL
     PING_MESSAGES
     ${Boost_LIBRARIES}
+    fmt::fmt
 )
 
 # test-device-ping1d
@@ -49,6 +54,7 @@ PRIVATE
     HAL
     PING_MESSAGES
     ${Boost_LIBRARIES}
+    fmt::fmt
 )
 
 # test-message

--- a/src/device/ping-device.cpp
+++ b/src/device/ping-device.cpp
@@ -75,19 +75,19 @@ void PingDevice::_handleMessage(const ping_message* message)
     case CommonId::NACK:
         break;
     case CommonId::PROTOCOL_VERSION: {
-        const common_protocol_version* protocol_version = static_cast<const common_protocol_version*>(message);
-        version_major = protocol_version->version_major();
-        version_minor = protocol_version->version_minor();
-        version_patch = protocol_version->version_patch();
+        const common_protocol_version* message_protocol_version = static_cast<const common_protocol_version*>(message);
+        protocol_version.version_major = message_protocol_version->version_major();
+        protocol_version.version_minor = message_protocol_version->version_minor();
+        protocol_version.version_patch = message_protocol_version->version_patch();
         break;
     }
     case CommonId::DEVICE_INFORMATION: {
-        const common_device_information* device_information = static_cast<const common_device_information*>(message);
-        device_type = device_information->device_type();
-        device_revision = device_information->device_revision();
-        firmware_version_major = device_information->firmware_version_major();
-        firmware_version_minor = device_information->firmware_version_minor();
-        firmware_version_patch = device_information->firmware_version_patch();
+        const common_device_information* message_device_information = static_cast<const common_device_information*>(message);
+        device_information.device_type = message_device_information->device_type();
+        device_information.device_revision = message_device_information->device_revision();
+        device_information.firmware_version_major = message_device_information->firmware_version_major();
+        device_information.firmware_version_minor = message_device_information->firmware_version_minor();
+        device_information.firmware_version_patch = message_device_information->firmware_version_patch();
         break;
     }
     default:

--- a/src/device/ping-device.h
+++ b/src/device/ping-device.h
@@ -106,14 +106,20 @@ public:
     void writeMessage(ping_message& message);
 
     uint8_t device_id;
-    uint8_t device_type;
-    uint8_t device_revision;
-    uint8_t firmware_version_major;
-    uint8_t firmware_version_minor;
-    uint8_t firmware_version_patch;
-    uint8_t version_major;
-    uint8_t version_minor;
-    uint8_t version_patch;
+
+    struct {
+        uint8_t device_type;
+        uint8_t device_revision;
+        uint8_t firmware_version_major;
+        uint8_t firmware_version_minor;
+        uint8_t firmware_version_patch;
+    } device_information;
+
+    struct {
+        uint8_t version_major;
+        uint8_t version_minor;
+        uint8_t version_patch;
+    } protocol_version;
 
 protected:
     /**

--- a/src/generate/templates/ping-device-ping1d.cpp.in
+++ b/src/generate/templates/ping-device-ping1d.cpp.in
@@ -7,8 +7,8 @@ Ping1d::~Ping1d()
 {% for msg in messages["get"]|sort %}
 {% for field in messages["get"][msg].payload %}
 {% if generator.is_vector(field.type) %}
-    if ({{field.name}}) {
-        delete[] {{field.name}};
+    if ({{msg}}_data.{{field.name}}) {
+        delete[] {{msg}}_data.{{field.name}};
     }
 {% endif %}
 {% endfor %}
@@ -39,23 +39,23 @@ void Ping1d::_handleMessage(const ping_message* message)
             const ping1d_{{msg}}* message_{{msg}} = static_cast<const ping1d_{{msg}}*>(message);
 {% for field in messages["get"][msg].payload %}
 {% if generator.is_vector(field.type) %}
-            if (message_{{msg}}->{{field.name}}_length() > {{field.name}}_length) {
-                if ({{field.name}}) {
-                    delete[] {{field.name}};
+            if (message_{{msg}}->{{field.name}}_length() > {{msg}}_data.{{field.name}}_length) {
+                if ({{msg}}_data.{{field.name}}) {
+                    delete[] {{msg}}_data.{{field.name}};
                 }
-                {{field.name}} = new {{generator.get_type_string(field.vector.datatype)}}[message_{{msg}}->{{field.name}}_length()];
+                {{msg}}_data.{{field.name}} = new {{generator.get_type_string(field.vector.datatype)}}[message_{{msg}}->{{field.name}}_length()];
             }
 
             // If pointer is invalid, make sure to abort, there is no more memory!
-            if (profile_data == nullptr) {
-                {{field.name}}_length = -1;
+            if (profile_data.profile_data == nullptr) {
+                {{msg}}_data.{{field.name}}_length = -1;
                 return;
             }
 
-            {{field.name}}_length = message_{{msg}}->{{field.name}}_length();
-            memcpy({{field.name}}, message_{{msg}}->{{field.name}}(), message_{{msg}}->{{field.name}}_length());
+            {{msg}}_data.{{field.name}}_length = message_{{msg}}->{{field.name}}_length();
+            memcpy({{msg}}_data.{{field.name}}, message_{{msg}}->{{field.name}}(), message_{{msg}}->{{field.name}}_length());
 {% else %}
-            {{field.name}} = message_{{msg}}->{{field.name}}();
+            {{msg}}_data.{{field.name}} = message_{{msg}}->{{field.name}}();
 {% endif %}
 {% endfor %}
         }
@@ -85,11 +85,14 @@ bool Ping1d::{{msg}}({% for field in messages["set"][msg].payload %}{{generator.
     // Read back the data and check that changes have been applied
     if (verify
 {% if messages["set"][msg].payload %}
+{% if msg != "set_device_id" %}
+        && ({% for field in messages["set"][msg].payload %}{{msg|replace("set_", "")}}_data.{{field.name}} != _{{field.name}}{{ "\n        || " if not loop.last }}{% endfor %})) {
+{% else %}
         && ({% for field in messages["set"][msg].payload %}{{field.name}} != _{{field.name}}{{ "\n        || " if not loop.last }}{% endfor %})) {
+{% endif %}
 {% endif %}
         return false;
     }
     return true;
 }
-
 {% endfor %}

--- a/src/generate/templates/ping-device-ping1d.h.in
+++ b/src/generate/templates/ping-device-ping1d.h.in
@@ -51,29 +51,23 @@ public:
     bool {{msg}}({% for field in messages["set"][msg].payload %}{{generator.get_type_string(field.type)}} {{field.name}}, {% endfor %}bool verify = true);
 
 {% endfor %}
-{% set propnames=[] %}
-{% set proplist=[] %}
-{% for msg in messages["get"] %}
-{% if not messages["get"][msg].deprecated %}
-{% for field in messages["get"][msg].payload %}
-{% if field.name not in propnames%}
-{{ '' if propnames.append(field.name) -}}
-{{ '' if proplist.append(field) -}}
-{% endif %}
-{% endfor %}
-{% endif %}
-{% endfor %}
-{% for field in proplist %}
-    // {{field.description}}
-{% if generator.is_vector(field.type) %}
-{% if field.vector.sizetype %}
-    {{generator.get_type_string(field.vector.sizetype)}} {{field.name}}_length = 0;
-{% endif %}
-    {{generator.get_type_string(field.vector.datatype)}}* {{field.name}} = 0;
-{% else %}
-    {{generator.get_type_string(field.type)}} {{field.name}} = 0;
-{% endif %}
 
+{% for msg in messages["get"]|sort %}
+{% if not messages["get"][msg].deprecated %}
+    //! {{messages["get"][msg].description}}
+    struct {
+{% for field in messages["get"][msg].payload %}
+        // {{field.description}}
+{% if not generator.is_vector(field.type) %}
+        {{generator.get_type_string(field.type)}} {{field.name}};
+{% else %}
+        {{generator.get_type_string(field.vector.datatype)}}* {{field.name}} = nullptr;
+        {{generator.get_type_string(field.vector.sizetype)}} {{field.name}}_length = 0;
+{% endif %}
+{% endfor %}
+    } {{msg}}_data;
+
+{% endif %}
 {% endfor %}
 
 private:

--- a/test/helper.h
+++ b/test/helper.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <functional>
+#include <string>
+
+#include <fmt/color.h>
+#include <fmt/core.h>
+
+class PingDeviceTest {
+public:
+    enum class Status {
+        // Something is wrong (invalid test)
+        ERROR = -1,
+        // It's a valid value but we can't make sure (generic test pass)
+        OK = 0,
+        // We are sure that the value is correct (value must be exact)
+        SUCCESS,
+    };
+
+    static void test(std::string testName, bool isOk, Status goodStatus = Status::SUCCESS) {
+        Status status = isOk ? goodStatus : Status::ERROR;
+        fmt::text_style style;
+        std::string result;
+        switch(status) { 
+            case Status::OK:
+                style = fg(fmt::color::white);
+                result = "OK";
+                break;
+            case Status::SUCCESS:
+                style = fg(fmt::terminal_color::bright_green);
+                result = "SUCCESS";
+                break;
+            default:
+                style = fmt::emphasis::bold | fg(fmt::color::red);
+                result = "ERROR";
+        }
+        fmt::print(style, "Test {}: {}\n", testName, result);
+
+        if (status == Status::ERROR) {
+            throw std::runtime_error(std::string("Test failed: ") + testName);
+        }
+    };
+
+    static void test(std::string testName, std::function<bool(void)> function, Status goodStatus = Status::SUCCESS) {
+        test(testName, function(), goodStatus);
+    };
+};

--- a/test/test-device-ping1d.cpp
+++ b/test/test-device-ping1d.cpp
@@ -4,6 +4,8 @@
 
 #include "command-line/command-line.h"
 
+#include "helper.h"
+
 #include <cstdio>
 
 /**
@@ -18,96 +20,55 @@ int main(int argc, char* argv[])
     auto port = AbstractLink::openUrl(CommandLine::self()->connectionString);
     Ping1d device = Ping1d(*port.get());
 
-    printf("initializing\n");
+    // Basic information
+    PingDeviceTest::test("Device initialization", device.initialize(100));
+    PingDeviceTest::test("Device type", static_cast<PingDeviceType>(device.device_information.device_type) == PingDeviceType::PING1D);
+    PingDeviceTest::test("Device ID", device.device_id == 1);
 
-    if (!device.initialize(100)) {
-        printf("device initialization failed\n");
-    } else {
-        printf("pass\n");
-        printf("Device Type %d id %d hardware revision %d\n", device.device_type, device.device_id,
-            device.device_revision);
-        printf("Ping Protocol v%d.%d.%d\n", device.version_major, device.version_minor, device.version_patch);
-        printf("Device Firmware v%d.%d.%d\n", device.firmware_version_major, device.firmware_version_minor,
-            device.firmware_version_patch);
-    }
+    PingDeviceTest::test("Ping protocol version",
+        device.protocol_version.version_major == 1);
+    PingDeviceTest::test("Device Firmware",
+        device.device_information.firmware_version_major >= 3 && device.device_information.firmware_version_minor >= 27);
 
-    printf("set device id\n");
-    if (!device.set_device_id(1)) {
-        printf("failed to set device id\n");
-    } else {
-        printf("pass\n");
-    }
+    // Test commands
+    PingDeviceTest::test("Set mode", device.set_mode_auto(true));
+    PingDeviceTest::test("Set range", !device.set_range(100, 2000)); // We can't set range in auto mode
+    PingDeviceTest::test("Set mode", device.set_mode_auto(false));
+    PingDeviceTest::test("Set range", device.set_range(100, 2000)); // We are not in auto mode anymore
 
-    printf("set range\n");
-    if (!device.set_range(100, 30000)) {
-        printf("failed to set scan range\n");
-    } else {
-        printf("pass\n");
-    }
+    PingDeviceTest::test("Set speed of sound", device.set_speed_of_sound(1550000));
+    PingDeviceTest::test("Set mode", device.set_mode_auto(false));
+    PingDeviceTest::test("Set interval", device.set_ping_interval(200));
+    PingDeviceTest::test("Set gain", device.set_gain_setting(1));
+    PingDeviceTest::test("Set ping enable", device.set_ping_enable(1));
 
-    printf("set range\n");
-    if (!device.set_speed_of_sound(1550000)) {
-        printf("failed to set scan range\n");
-    } else {
-        printf("pass\n");
-    }
-
-    printf("set mode auto\n");
-    if (!device.set_mode_auto(false)) {
-        printf("failed to set device mode auto\n");
-    } else {
-        printf("pass\n");
-    }
-
-    printf("set ping interval\n");
-    if (!device.set_ping_interval(200)) {
-        printf("failed to set ping interval\n");
-    } else {
-        printf("pass\n");
-    }
-
-    printf("set gain setting\n");
-    if (!device.set_gain_setting(1)) {
-        printf("failed to set gain setting\n");
-    } else {
-        printf("pass\n");
-    }
-
-    printf("set ping enable\n");
-    if (!device.set_ping_enable(1)) {
-        printf("failed to set ping enable\n");
-    } else {
-        printf("pass\n");
-    }
-
-    auto testRequest = [&device](uint16_t msgId, const char* message = nullptr) {
-        printf("requesting message: %s\n",
-            message ? message : PingHelper::nameFromMessageId(static_cast<PingEnumNamespace::PingMessageId>(msgId)));
-        if (!device.request(msgId, 1000)) {
-            printf("fail\n");
-            return false;
-        }
-
-        printf("pass\n");
-        return true;
+    // Test request
+    auto requestIDs = {
+        Ping1dId::FIRMWARE_VERSION,
+        Ping1dId::DEVICE_ID,
+        Ping1dId::VOLTAGE_5,
+        Ping1dId::SPEED_OF_SOUND,
+        Ping1dId::RANGE,
+        Ping1dId::MODE_AUTO,
+        Ping1dId::PING_INTERVAL,
+        Ping1dId::GAIN_SETTING,
+        Ping1dId::TRANSMIT_DURATION,
+        Ping1dId::GENERAL_INFO,
+        Ping1dId::DISTANCE_SIMPLE,
+        Ping1dId::DISTANCE,
+        Ping1dId::PROCESSOR_TEMPERATURE,
+        Ping1dId::PCB_TEMPERATURE,
+        Ping1dId::PING_ENABLE,
+        Ping1dId::PROFILE,
     };
 
-    testRequest(Ping1dId::FIRMWARE_VERSION);
-    testRequest(Ping1dId::DEVICE_ID);
-    testRequest(Ping1dId::VOLTAGE_5);
-    testRequest(Ping1dId::SPEED_OF_SOUND);
-    testRequest(Ping1dId::RANGE);
-    testRequest(Ping1dId::MODE_AUTO);
-    testRequest(Ping1dId::PING_INTERVAL);
-    testRequest(Ping1dId::GAIN_SETTING);
-    testRequest(Ping1dId::TRANSMIT_DURATION);
-    testRequest(Ping1dId::GENERAL_INFO);
-    testRequest(Ping1dId::DISTANCE_SIMPLE);
-    testRequest(Ping1dId::DISTANCE);
-    testRequest(Ping1dId::PROCESSOR_TEMPERATURE);
-    testRequest(Ping1dId::PCB_TEMPERATURE);
-    testRequest(Ping1dId::PING_ENABLE);
-    testRequest(Ping1dId::PROFILE);
+    for (auto id : requestIDs) {
+        std::string title = "Requesting message [";
+        title.append(PingHelper::nameFromMessageId(static_cast<PingEnumNamespace::PingMessageId>(id)));
+        title.append("]");
+
+        PingDeviceTest::test(title, device.request(id, 1000));
+    }
 
     return 0;
 }


### PR DESCRIPTION
- Move device class to have device information struct based by message
    - With that, it was possible to find two errors in the old test implementation related to variables declared with the same name between base and specific class (ping-device and ping1d)
- Add more tests
- Fix test failure.
    - Add hard fail if test does not passes (test was failing without triggering failure in CI)
- Add a human friendly output

new:
![image](https://user-images.githubusercontent.com/1215497/79283178-677daf00-7e8d-11ea-97bb-f1cd97ac3da3.png)
and if something fail:
![image](https://user-images.githubusercontent.com/1215497/79283905-9432c600-7e8f-11ea-9911-0946e194b4c3.png)


old:
![image](https://user-images.githubusercontent.com/1215497/79283199-78c6bb80-7e8d-11ea-8036-0da981656a07.png)
