### PR TITLE
hal: Add missing thread include for desktop/serial-link

### DIFF
--- a/src/hal/link/desktop/serial-link.cpp
+++ b/src/hal/link/desktop/serial-link.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <thread>
 
 #include "serial-link.h"
 


### PR DESCRIPTION
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>