### PR TITLE
Fix yeild typo (yeild -> yield)

### DIFF
--- a/src/device/ping-device.cpp
+++ b/src/device/ping-device.cpp
@@ -53,7 +53,7 @@ ping_message* PingDevice::waitMessage(uint16_t id, int timeoutMs)
             return message;
         }
         // Prevent cpu spinlock
-        PingTime::yeild();
+        PingTime::yield();
     }
 
     return nullptr;

--- a/src/hal/time/desktop/ping-time.cpp
+++ b/src/hal/time/desktop/ping-time.cpp
@@ -18,4 +18,4 @@ void PingTime::microsecondDelay(unsigned int microseconds)
     std::this_thread::sleep_for(std::chrono::microseconds(microseconds));
 }
 
-void PingTime::yeild() { std::this_thread::yield(); }
+void PingTime::yield() { std::this_thread::yield(); }

--- a/src/hal/time/ping-time.h
+++ b/src/hal/time/ping-time.h
@@ -7,5 +7,5 @@
 namespace PingTime {
 void microsecondDelay(unsigned int microseconds);
 int timeMs();
-void yeild();
+void yield();
 }


### PR DESCRIPTION
Technically changes the API, although it's to fix a spelling mistake which should reduce development errors going forwards.