### PR TITLE
src: device: ping-device.cpp: add auto-baud support

### DIFF
--- a/src/device/ping-device.cpp
+++ b/src/device/ping-device.cpp
@@ -5,7 +5,14 @@
 
 #include <cstdio>
 
-bool PingDevice::initialize() { return request(CommonId::PROTOCOL_VERSION) && request(CommonId::DEVICE_INFORMATION); }
+bool PingDevice::initialize() 
+{
+    // write a byte of alternating bits, to allow auto-baudrate detection
+    static const uint8_t detection_byte = 0b01010101;
+    _port.write(&detection_byte, 1);
+    // attempt to initialise by extracting common information
+    return request(CommonId::PROTOCOL_VERSION) && request(CommonId::DEVICE_INFORMATION);
+}
 
 ping_message* PingDevice::read()
 {


### PR DESCRIPTION
Ping firmwares which support automatic serial baudrate detection require a sequence of alternating bits at the start of communication to determine the baudrate.

This roughly matches the existing behaviour implemented in [`ping-arduino`](https://github.com/bluerobotics/ping-arduino/blob/master/src/ping1d.cpp#L42) and [`ping-python`](https://github.com/bluerobotics/ping-python/blob/master/generate/templates/device.py.in#L54). The primary difference is that in `ping-python` the detection byte is only sent for serial connections (`ping-arduino` only supports serial connections, so is unrelated). I'm unsure if this is likely to/could cause any issues with UDP connections, but the hal exists to separate the device from the communication method, so it's definitely preferable to not have to handle that manually. 

Hopefully UDP connections are able to correctly reject the detection byte as noise, but that likely needs testing before this gets merged.