### PR TITLE
Add CMake option to disable building tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ include_directories(${Boost_INCLUDE_DIR})
 # Include modules
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-option(PING_CPP_BUILD_TESTS "" ON)
+option(PING_CPP_BUILD_TESTS "Build the test cases when PING_CPP_BUILD_TESTS is enabled." ON)
 message("Building tests: ${PING_CPP_BUILD_TESTS}")
 
 if (PING_CPP_BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,70 +21,80 @@ include_directories(${Boost_INCLUDE_DIR})
 # Include modules
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-# Add fmt
-include_directories(lib/fmt/include/)
-add_subdirectory(lib/fmt/)
+message("Building tests: ${PING_CPP_BUILD_TESTS}")
+if(NOT DEFINED PING_CPP_BUILD_TESTS)
+    set(PING_CPP_BUILD_TESTS true)
+endif()
 
-# test-device
-add_executable(test-device)
-target_sources(
-    test-device
-PRIVATE
-    test/test-device.cpp
-)
-target_link_libraries(
-    test-device
-PRIVATE
-    DEVICE
-    HAL
-    PING_MESSAGES
-    ${Boost_LIBRARIES}
-    fmt::fmt
-)
+if (PING_CPP_BUILD_TESTS MATCHES "true")
+    # Add fmt subdirectory
+    add_subdirectory(lib/fmt/)
 
-# test-device-ping1d
-add_executable(test-device-ping1d)
-target_sources(
-    test-device-ping1d
-PRIVATE
-    test/test-device-ping1d.cpp
-)
-target_link_libraries(
-    test-device-ping1d
-PRIVATE
-    DEVICE
-    HAL
-    PING_MESSAGES
-    ${Boost_LIBRARIES}
-    fmt::fmt
-)
+    # test-device
+    add_executable(test-device)
+    target_include_directories(test-device PRIVATE lib/fmt/include/)
+    target_sources(
+        test-device
+    PRIVATE
+        test/test-device.cpp
+    )
+    target_link_libraries(
+        test-device
+    PRIVATE
+        DEVICE
+        HAL
+        PING_MESSAGES
+        ${Boost_LIBRARIES}
+        fmt::fmt
+    )
 
-# test-device-ping1d
-add_executable(test-device-ping360)
-target_sources(
-    test-device-ping360
-PRIVATE
-    test/test-device-ping360.cpp
-)
-target_link_libraries(
-    test-device-ping360
-PRIVATE
-    DEVICE
-    HAL
-    PING_MESSAGES
-    ${Boost_LIBRARIES}
-    fmt::fmt
-)
+    # test-device-ping1d
+    add_executable(test-device-ping1d)
+    target_include_directories(test-device-ping1d PRIVATE lib/fmt/include/)
+    target_sources(
+        test-device-ping1d
+    PRIVATE
+        test/test-device-ping1d.cpp
+    )
+    target_link_libraries(
+        test-device-ping1d
+    PRIVATE
+        DEVICE
+        HAL
+        PING_MESSAGES
+        ${Boost_LIBRARIES}
+        fmt::fmt
+    )
 
-# test-message
-add_executable(test-message)
-target_sources(
-    test-message
-PRIVATE
-    test/test-message.cpp
-)
-target_link_libraries(
-    test-message
-PRIVATE
-    PING_MESSAGES
-)
+    # test-device-ping360
+    add_executable(test-device-ping360)
+    target_include_directories(test-device-ping360 PRIVATE lib/fmt/include/)
+    target_sources(
+        test-device-ping360
+    PRIVATE
+        test/test-device-ping360.cpp
+    )
+    target_link_libraries(
+        test-device-ping360
+    PRIVATE
+        DEVICE
+        HAL
+        PING_MESSAGES
+        ${Boost_LIBRARIES}
+        fmt::fmt
+    )
+
+    # test-message
+    add_executable(test-message)
+    target_include_directories(test-message PRIVATE lib/fmt/include/)
+    target_sources(
+        test-message
+    PRIVATE
+        test/test-message.cpp
+    )
+    target_link_libraries(
+        test-message
+    PRIVATE
+        PING_MESSAGES
+    )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ include_directories(${Boost_INCLUDE_DIR})
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 option(PING_CPP_BUILD_TESTS "Build the test cases when PING_CPP_BUILD_TESTS is enabled." ON)
-message("Building tests: ${PING_CPP_BUILD_TESTS}")
 
 if (PING_CPP_BUILD_TESTS)
     # Add fmt subdirectory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,80 +21,78 @@ include_directories(${Boost_INCLUDE_DIR})
 # Include modules
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)
 
+option(PING_CPP_BUILD_TESTS "" ON)
 message("Building tests: ${PING_CPP_BUILD_TESTS}")
-if(NOT DEFINED PING_CPP_BUILD_TESTS)
-    set(PING_CPP_BUILD_TESTS true)
+
+if (PING_CPP_BUILD_TESTS)
+    # Add fmt subdirectory
+    add_subdirectory(lib/fmt/)
+
+    # test-device
+    add_executable(test-device)
+    target_include_directories(test-device PRIVATE lib/fmt/include/)
+    target_sources(
+        test-device
+    PRIVATE
+        test/test-device.cpp
+    )
+    target_link_libraries(
+        test-device
+    PRIVATE
+        DEVICE
+        HAL
+        PING_MESSAGES
+        ${Boost_LIBRARIES}
+        fmt::fmt
+    )
+
+    # test-device-ping1d
+    add_executable(test-device-ping1d)
+    target_include_directories(test-device-ping1d PRIVATE lib/fmt/include/)
+    target_sources(
+        test-device-ping1d
+    PRIVATE
+        test/test-device-ping1d.cpp
+    )
+    target_link_libraries(
+        test-device-ping1d
+    PRIVATE
+        DEVICE
+        HAL
+        PING_MESSAGES
+        ${Boost_LIBRARIES}
+        fmt::fmt
+    )
+
+    # test-device-ping360
+    add_executable(test-device-ping360)
+    target_include_directories(test-device-ping360 PRIVATE lib/fmt/include/)
+    target_sources(
+        test-device-ping360
+    PRIVATE
+        test/test-device-ping360.cpp
+    )
+    target_link_libraries(
+        test-device-ping360
+    PRIVATE
+        DEVICE
+        HAL
+        PING_MESSAGES
+        ${Boost_LIBRARIES}
+        fmt::fmt
+    )
+
+    # test-message
+    add_executable(test-message)
+    target_include_directories(test-message PRIVATE lib/fmt/include/)
+    target_sources(
+        test-message
+    PRIVATE
+        test/test-message.cpp
+    )
+    target_link_libraries(
+        test-message
+    PRIVATE
+        PING_MESSAGES
+    )
 endif()
-
-# if (PING_CPP_BUILD_TESTS MATCHES "true")
-#     # Add fmt subdirectory
-#     add_subdirectory(lib/fmt/)
-
-#     # test-device
-#     add_executable(test-device)
-#     target_include_directories(test-device PRIVATE lib/fmt/include/)
-#     target_sources(
-#         test-device
-#     PRIVATE
-#         test/test-device.cpp
-#     )
-#     target_link_libraries(
-#         test-device
-#     PRIVATE
-#         DEVICE
-#         HAL
-#         PING_MESSAGES
-#         ${Boost_LIBRARIES}
-#         fmt::fmt
-#     )
-
-#     # test-device-ping1d
-#     add_executable(test-device-ping1d)
-#     target_include_directories(test-device-ping1d PRIVATE lib/fmt/include/)
-#     target_sources(
-#         test-device-ping1d
-#     PRIVATE
-#         test/test-device-ping1d.cpp
-#     )
-#     target_link_libraries(
-#         test-device-ping1d
-#     PRIVATE
-#         DEVICE
-#         HAL
-#         PING_MESSAGES
-#         ${Boost_LIBRARIES}
-#         fmt::fmt
-#     )
-
-#     # test-device-ping360
-#     add_executable(test-device-ping360)
-#     target_include_directories(test-device-ping360 PRIVATE lib/fmt/include/)
-#     target_sources(
-#         test-device-ping360
-#     PRIVATE
-#         test/test-device-ping360.cpp
-#     )
-#     target_link_libraries(
-#         test-device-ping360
-#     PRIVATE
-#         DEVICE
-#         HAL
-#         PING_MESSAGES
-#         ${Boost_LIBRARIES}
-#         fmt::fmt
-#     )
-
-#     # test-message
-#     add_executable(test-message)
-#     target_include_directories(test-message PRIVATE lib/fmt/include/)
-#     target_sources(
-#         test-message
-#     PRIVATE
-#         test/test-message.cpp
-#     )
-#     target_link_libraries(
-#         test-message
-#     PRIVATE
-#         PING_MESSAGES
-#     )
-# endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,75 +26,75 @@ if(NOT DEFINED PING_CPP_BUILD_TESTS)
     set(PING_CPP_BUILD_TESTS true)
 endif()
 
-if (PING_CPP_BUILD_TESTS MATCHES "true")
-    # Add fmt subdirectory
-    add_subdirectory(lib/fmt/)
+# if (PING_CPP_BUILD_TESTS MATCHES "true")
+#     # Add fmt subdirectory
+#     add_subdirectory(lib/fmt/)
 
-    # test-device
-    add_executable(test-device)
-    target_include_directories(test-device PRIVATE lib/fmt/include/)
-    target_sources(
-        test-device
-    PRIVATE
-        test/test-device.cpp
-    )
-    target_link_libraries(
-        test-device
-    PRIVATE
-        DEVICE
-        HAL
-        PING_MESSAGES
-        ${Boost_LIBRARIES}
-        fmt::fmt
-    )
+#     # test-device
+#     add_executable(test-device)
+#     target_include_directories(test-device PRIVATE lib/fmt/include/)
+#     target_sources(
+#         test-device
+#     PRIVATE
+#         test/test-device.cpp
+#     )
+#     target_link_libraries(
+#         test-device
+#     PRIVATE
+#         DEVICE
+#         HAL
+#         PING_MESSAGES
+#         ${Boost_LIBRARIES}
+#         fmt::fmt
+#     )
 
-    # test-device-ping1d
-    add_executable(test-device-ping1d)
-    target_include_directories(test-device-ping1d PRIVATE lib/fmt/include/)
-    target_sources(
-        test-device-ping1d
-    PRIVATE
-        test/test-device-ping1d.cpp
-    )
-    target_link_libraries(
-        test-device-ping1d
-    PRIVATE
-        DEVICE
-        HAL
-        PING_MESSAGES
-        ${Boost_LIBRARIES}
-        fmt::fmt
-    )
+#     # test-device-ping1d
+#     add_executable(test-device-ping1d)
+#     target_include_directories(test-device-ping1d PRIVATE lib/fmt/include/)
+#     target_sources(
+#         test-device-ping1d
+#     PRIVATE
+#         test/test-device-ping1d.cpp
+#     )
+#     target_link_libraries(
+#         test-device-ping1d
+#     PRIVATE
+#         DEVICE
+#         HAL
+#         PING_MESSAGES
+#         ${Boost_LIBRARIES}
+#         fmt::fmt
+#     )
 
-    # test-device-ping360
-    add_executable(test-device-ping360)
-    target_include_directories(test-device-ping360 PRIVATE lib/fmt/include/)
-    target_sources(
-        test-device-ping360
-    PRIVATE
-        test/test-device-ping360.cpp
-    )
-    target_link_libraries(
-        test-device-ping360
-    PRIVATE
-        DEVICE
-        HAL
-        PING_MESSAGES
-        ${Boost_LIBRARIES}
-        fmt::fmt
-    )
+#     # test-device-ping360
+#     add_executable(test-device-ping360)
+#     target_include_directories(test-device-ping360 PRIVATE lib/fmt/include/)
+#     target_sources(
+#         test-device-ping360
+#     PRIVATE
+#         test/test-device-ping360.cpp
+#     )
+#     target_link_libraries(
+#         test-device-ping360
+#     PRIVATE
+#         DEVICE
+#         HAL
+#         PING_MESSAGES
+#         ${Boost_LIBRARIES}
+#         fmt::fmt
+#     )
 
-    # test-message
-    add_executable(test-message)
-    target_include_directories(test-message PRIVATE lib/fmt/include/)
-    target_sources(
-        test-message
-    PRIVATE
-        test/test-message.cpp
-    )
-    target_link_libraries(
-        test-message
-    PRIVATE
-        PING_MESSAGES
-    )
-endif()
+#     # test-message
+#     add_executable(test-message)
+#     target_include_directories(test-message PRIVATE lib/fmt/include/)
+#     target_sources(
+#         test-message
+#     PRIVATE
+#         test/test-message.cpp
+#     )
+#     target_link_libraries(
+#         test-message
+#     PRIVATE
+#         PING_MESSAGES
+#     )
+# endif()


### PR DESCRIPTION
## Overview

This PR adds a CMake option to toggle building the tests, which defaults to enabled. It's common for downstream projects to disable building the tests for external projects to reduce compile time.

By default, `PING_CPP_BUILD_TESTS` is set to `ON`, so the tests will still build.

Consumers of the library who want to disable building the tests can set the option before including the project:
```
option(PING_CPP_BUILD_TESTS "" OFF)
```