### PR TITLE
ping-message.h/ping-message-.h: Add no copy constructor

### DIFF
--- a/src/generate/templates/ping-message-.h.in
+++ b/src/generate/templates/ping-message-.h.in
@@ -30,6 +30,7 @@ class {{class_name}} : public ping_message
 {
 public:
     {{class_name}}(const ping_message& msg) : ping_message { msg } {}
+    {{class_name}}(uint8_t* buf) : ping_message { buf, {{8 + total_payload + 2}} } {}
     {{class_name}}(const uint8_t* buf, const uint16_t length) : ping_message { buf, length } {}
     {{class_name}}(
 {%- for payload in m.payload %}

--- a/test/test-device-ping360.cpp
+++ b/test/test-device-ping360.cpp
@@ -43,7 +43,7 @@ int main(int argc, char* argv[])
             ,0          //reserved
         );
 
-        const auto message_device_data = static_cast<const ping360_device_data*>(device.waitMessage(Ping360Id::DEVICE_DATA, 8000));
+        [[maybe_unused]] const auto message_device_data = static_cast<const ping360_device_data*>(device.waitMessage(Ping360Id::DEVICE_DATA, 8000));
         assert(message_device_data);
         assert(message_device_data->angle() == number);
     }
@@ -62,7 +62,7 @@ int main(int argc, char* argv[])
         ,0          //delay
     );
     for(int number = 0; number < 200; number += 1) {
-        const auto message_device_data = static_cast<const ping360_auto_device_data*>(device.waitMessage(Ping360Id::AUTO_DEVICE_DATA, 8000));
+        [[maybe_unused]] const auto message_device_data = static_cast<const ping360_auto_device_data*>(device.waitMessage(Ping360Id::AUTO_DEVICE_DATA, 8000));
         assert(message_device_data);
         assert(message_device_data->angle() == number);
     }


### PR DESCRIPTION
This PR continue #55 and implements zero copy option to allow using ping messages with external memory buffers.