### PR TITLE
templates: ping-message-.h: Fix variable length

### DIFF
--- a/src/generate/templates/ping-message-.h.in
+++ b/src/generate/templates/ping-message-.h.in
@@ -30,7 +30,23 @@ class {{class_name}} : public ping_message
 {
 public:
     {{class_name}}(const ping_message& msg) : ping_message { msg } {}
-    {{class_name}}(uint8_t* buf) : ping_message { buf, {{8 + total_payload + 2}} }
+    {{class_name}}(uint8_t* buf
+{%- for payload in m.payload %}
+{% if generator.is_vector(payload.type) %},
+{% if payload.vector.sizetype -%}
+            {{generator.get_type_string(payload.vector.sizetype)}} {{payload.name}}_length
+{% else -%}
+            uint16_t {{payload.name}}_length
+{%- endif %}
+{% endif %}
+{% endfor %}{# each payload field #}
+) : ping_message { buf, static_cast<uint16_t>({{8 + total_payload + 2}}
+{%- for payload in m.payload %}
+{% if generator.is_vector(payload.type) %}
+ + {{payload.name}}_length
+{%- endif %}
+{% endfor %}) }{# each payload field #}
+
     {
         msgData[0] = 'B';
         msgData[1] = 'R';


### PR DESCRIPTION
* Fix case in external ref to buffer constructor does not take in account variable payload sizes like profile length

Before the code would not take in account variable length fields
```
ping1d_profile(uint8_t* buf) : ping_message { buf, 36 }
```

With the fix
```
ping1d_profile(uint8_t* buf,
uint16_t profile_data_length
) : ping_message { buf, static_cast<uint16_t>(36 + profile_data_length) }
```